### PR TITLE
Fix capitalization error in Hungarian translation

### DIFF
--- a/lib/translations/hu_HU.js
+++ b/lib/translations/hu_HU.js
@@ -4,7 +4,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'január', 'február', 'március', 'április', 'május', 'június', 'július', 'augusztus', 'szeptember', 'október', 'november', 'december' ],
     monthsShort: [ 'jan', 'febr', 'márc', 'ápr', 'máj', 'jún', 'júl', 'aug', 'szept', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'vasárnap', 'hétfő', 'kedd', 'szerda', 'csütörtök', 'péntek', 'szombat' ],
-    weekdaysShort: [ 'V', 'H', 'K', 'SZe', 'CS', 'P', 'SZo' ],
+    weekdaysShort: [ 'V', 'H', 'K', 'Sze', 'Cs', 'P', 'Szo' ],
     today: 'Ma',
     clear: 'Törlés',
     firstDay: 1,


### PR DESCRIPTION
We do not capitalize the second letter of digraphs in Hungarian
